### PR TITLE
Allow migrations to run on deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ FROM node:lts-alpine
 WORKDIR /app/
 COPY --from=builder /build/package.json /build/yarn.lock /app/
 COPY --from=builder /build/dist /app/dist
+COPY --from=builder /build/prisma /app/prisma
 RUN yarn install --frozen-lockfile --production=true
 EXPOSE 8000
-CMD yarn start
+CMD yarn start:prod

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"dev": "ts-node src/index.ts",
 		"build": "tsc",
 		"start": "node dist/index.js",
+		"start:prod": "prisma migrate deploy && node dist/index.js",
 		"test": "jest",
 		"lint": "prettier --check src test *.md *.json",
 		"format": "prettier --write src test *.md *.json"
@@ -27,7 +28,8 @@
 		"fastify": "^4.10.2",
 		"moment": "^2.29.4",
 		"nanoid": "^3.3.4",
-		"nodemailer": "^6.8.0"
+		"nodemailer": "^6.8.0",
+		"prisma": "^4.8.0"
 	},
 	"devDependencies": {
 		"@faker-js/faker": "^7.6.0",
@@ -41,7 +43,6 @@
 		"jest": "^29.3.1",
 		"jest-when": "^3.5.2",
 		"prettier": "^2.8.1",
-		"prisma": "^4.8.0",
 		"supertest": "^6.3.3",
 		"ts-jest": "^29.0.5",
 		"ts-node": "^10.9.1",


### PR DESCRIPTION
- Adds `start:prod` script
- Moves `prisma` to `dependencies`