### PR TITLE
Rework update user role logic

### DIFF
--- a/src/server/list/list.routes.ts
+++ b/src/server/list/list.routes.ts
@@ -1,5 +1,6 @@
 import { Express } from 'express';
 import { roleIsAtLeast, tokenAuthentication } from '../../utils/authentication';
+import bodyFilter from '../../utils/bodyFilter';
 import route from '../../utils/route';
 import { isCreateListProps, isUpdateListProps } from './list.model';
 import { createList, findList, findLists, updateList } from './list.service';
@@ -37,7 +38,7 @@ export default function (server: Express) {
 			const caller = await tokenAuthentication(req, res);
 			if (!caller) return res.headersSent || res.sendStatus(500);
 
-			const props = req.body;
+			const props = bodyFilter(req.body, ['type', 'version', 'structure', 'colors']);
 			if (!isCreateListProps(props))
 				return res.status(422).send('Provided properties can not create a list');
 
@@ -57,7 +58,15 @@ export default function (server: Express) {
 			const list = await findList(id);
 			if (!list) return res.status(404).send(`No list exists with the id ${id}`);
 
-			const props = req.body;
+			const props = bodyFilter(req.body, [
+				'fields',
+				'responsible',
+				'phoneNumber',
+				'eventDate',
+				'comment',
+				'submitted',
+				'verified',
+			]);
 			if (!isUpdateListProps(props))
 				return res.status(422).send('Provided properties cannot edit a list');
 

--- a/src/utils/bodyFilter.ts
+++ b/src/utils/bodyFilter.ts
@@ -1,0 +1,12 @@
+type FilteredBody = Record<string, any>;
+
+export default function bodyFilter(body: any, allowedKyes: string[]): FilteredBody | null {
+	if (typeof body !== 'object') return null;
+
+	const filteredBody: FilteredBody = {};
+	for (const key in body) {
+		if (!allowedKyes.includes(key)) continue;
+		filteredBody[key] = body[key];
+	}
+	return filteredBody;
+}

--- a/test/src/utils/bodyFilter.test.ts
+++ b/test/src/utils/bodyFilter.test.ts
@@ -1,0 +1,15 @@
+import bodyFilter from '../../../src/utils/bodyFilter';
+
+describe('bodyFilter', () => {
+	it('Returns filtered object', () => {
+		const allowedKeys = ['foo', 'bar', 'zot'];
+		const validObject = { foo: 'foo', bar: 0, zot: null };
+		const invalidProperties = { baz: 'baz', qux: { foo: 99 } };
+
+		expect(bodyFilter({ ...validObject, ...invalidProperties }, allowedKeys)).toEqual(validObject);
+	});
+
+	it('Returns null if provided body is not object', () => {
+		expect(bodyFilter(9, [])).toBeNull();
+	});
+});


### PR DESCRIPTION
- Prevents users from changing their own role
- Only allows users to edit themselves or users with a lower role
- Adds filters to bodies in POST/PATCH request

Resolves #7
Resolves #8
Resolves #9