### PR TITLE
Prevent list event date from being set in the future

### DIFF
--- a/src/server/list/list.routes.ts
+++ b/src/server/list/list.routes.ts
@@ -1,4 +1,5 @@
 import { Express } from 'express';
+import moment from 'moment';
 import { roleIsAtLeast, tokenAuthentication } from '../../utils/authentication';
 import bodyFilter from '../../utils/bodyFilter';
 import route from '../../utils/route';
@@ -69,6 +70,8 @@ export default function (server: Express) {
 			]);
 			if (!isUpdateListProps(props))
 				return res.status(422).send('Provided properties cannot edit a list');
+			if (props.eventDate && moment().isBefore(props.eventDate))
+				return res.status(422).send('Event date cannot be in the future');
 
 			if (
 				caller.handle !== list.createdBy.handle &&

--- a/test/src/server/list.routes.test.ts
+++ b/test/src/server/list.routes.test.ts
@@ -186,8 +186,21 @@ describe('PATCH /lists/:id', () => {
 		when(findList).calledWith(1).mockResolvedValue(list);
 
 		const props = { comment: 5 };
-
 		const response = await supertest(server).patch('/lists/1').send(props);
+
+		expect(response.status).toBe(422);
+		expect(findList).toHaveBeenCalledTimes(1);
+		expect(tokenAuthentication).toHaveBeenCalledTimes(1);
+	});
+
+	it('Returns 422 for eventDate in the future', async () => {
+		when(tokenAuthentication).mockResolvedValue(primary);
+		const list = usableListFactory({ id: 1 });
+		when(findList).calledWith(1).mockResolvedValue(list);
+
+		const props = { eventDate: faker.date.future().toISOString().slice(0, 10) };
+		const response = await supertest(server).patch('/lists/1').send(props);
+
 		expect(response.status).toBe(422);
 		expect(findList).toHaveBeenCalledTimes(1);
 		expect(tokenAuthentication).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
- Add check for `eventDate` property in `UpdateListProps` to not be in the future

Resolves #11