### PR TITLE
Track users' last sign in and allow upper case characters in handles

### DIFF
--- a/prisma/migrations/20230213153541_sign_in_tracker/migration.sql
+++ b/prisma/migrations/20230213153541_sign_in_tracker/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "lastSignedIn" TIMESTAMP(3);

--- a/prisma/migrations/20230216131333_case_insensitive_handle/migration.sql
+++ b/prisma/migrations/20230216131333_case_insensitive_handle/migration.sql
@@ -1,0 +1,49 @@
+/*
+  Warnings:
+
+  - The primary key for the `User` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+
+CREATE EXTENSION citext;
+
+-- DropForeignKey
+ALTER TABLE "List" DROP CONSTRAINT "List_createdByHandle_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ResetToken" DROP CONSTRAINT "ResetToken_userHandle_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Secret" DROP CONSTRAINT "Secret_generatedByHandle_fkey";
+
+-- DropForeignKey
+ALTER TABLE "UserToken" DROP CONSTRAINT "UserToken_userHandle_fkey";
+
+-- AlterTable
+ALTER TABLE "List" ALTER COLUMN "createdByHandle" SET DATA TYPE CITEXT;
+
+-- AlterTable
+ALTER TABLE "ResetToken" ALTER COLUMN "userHandle" SET DATA TYPE CITEXT;
+
+-- AlterTable
+ALTER TABLE "Secret" ALTER COLUMN "generatedByHandle" SET DATA TYPE CITEXT;
+
+-- AlterTable
+ALTER TABLE "User" DROP CONSTRAINT "User_pkey",
+ALTER COLUMN "handle" SET DATA TYPE CITEXT,
+ADD CONSTRAINT "User_pkey" PRIMARY KEY ("handle");
+
+-- AlterTable
+ALTER TABLE "UserToken" ALTER COLUMN "userHandle" SET DATA TYPE CITEXT;
+
+-- AddForeignKey
+ALTER TABLE "UserToken" ADD CONSTRAINT "UserToken_userHandle_fkey" FOREIGN KEY ("userHandle") REFERENCES "User"("handle") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "List" ADD CONSTRAINT "List_createdByHandle_fkey" FOREIGN KEY ("createdByHandle") REFERENCES "User"("handle") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Secret" ADD CONSTRAINT "Secret_generatedByHandle_fkey" FOREIGN KEY ("generatedByHandle") REFERENCES "User"("handle") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ResetToken" ADD CONSTRAINT "ResetToken_userHandle_fkey" FOREIGN KEY ("userHandle") REFERENCES "User"("handle") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,7 @@ model User {
   role         Role        @default(BASE)
   lists        List[]
   visible      Boolean     @default(true)
+  lastSignedIn DateTime?
   token        UserToken?
   resetToken   ResetToken?
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,7 +2,8 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
+  previewFeatures = ["postgresqlExtensions"]
 }
 
 datasource db {
@@ -11,12 +12,12 @@ datasource db {
 }
 
 model User {
-  handle       String      @id
+  handle       String      @id @db.Citext
   name         String
   email        String?     @unique
   passwordHash String
   role         Role        @default(BASE)
-  lists        List[]
+  createdLists List[]      @relation(name: "listCreator")
   visible      Boolean     @default(true)
   lastSignedIn DateTime?
   token        UserToken?
@@ -33,7 +34,7 @@ model UserToken {
   expiresAt DateTime
   user      User     @relation(fields: [userHandle], references: [handle], onDelete: Cascade)
 
-  userHandle String @unique
+  userHandle String @unique @db.Citext
 }
 
 model List {
@@ -49,11 +50,11 @@ model List {
   comment     String?
   submitted   Boolean  @default(false)
   verified    Boolean  @default(false)
-  createdBy   User     @relation(fields: [createdByHandle], references: [handle])
+  createdBy   User     @relation(fields: [createdByHandle], references: [handle], name: "listCreator")
   createdAt   DateTime @default(now())
   updatedAt   DateTime @default(now())
 
-  createdByHandle String
+  createdByHandle String @db.Citext
 }
 
 model Secret {
@@ -61,7 +62,7 @@ model Secret {
   secretHash  String
   generatedBy User   @relation(fields: [generatedByHandle], references: [handle])
 
-  generatedByHandle String
+  generatedByHandle String @db.Citext
 }
 
 model ResetToken {
@@ -69,7 +70,7 @@ model ResetToken {
   validUntil DateTime
   user       User     @relation(fields: [userHandle], references: [handle], onDelete: Cascade)
 
-  userHandle String @unique
+  userHandle String @unique @db.Citext
 }
 
 enum Role {

--- a/src/server/user/user.service.ts
+++ b/src/server/user/user.service.ts
@@ -46,14 +46,13 @@ export async function findUserFromEmail(email: string): Promise<UsableUser | nul
 }
 
 export async function createUser(
-	{ password, handle, ...props }: CreateUserProps,
+	{ password, ...props }: CreateUserProps,
 	setSignIn = false
 ): Promise<UsableUser> {
 	const passwordHash = await generatePasswordHash(password);
 	return (await prismaClient.user.create({
 		data: {
 			...props,
-			handle: handle.toLowerCase(),
 			passwordHash,
 			lastSignedIn: setSignIn ? new Date() : undefined,
 			token: await newToken(),


### PR DESCRIPTION
- Adds `lastSignIn` field to `User` model
- Change type of `"User"."handle"` to be `CITEXT` to make handles case-insensitive

Resolves #13
Resolves #23