### PR TITLE
Allow list ownerwhip to be transferred and change submitted and verified functionality

### DIFF
--- a/prisma/migrations/20230216204423_add_owned_by_to_list/migration.sql
+++ b/prisma/migrations/20230216204423_add_owned_by_to_list/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "List" ADD COLUMN     "ownedByHandle" CITEXT;
+
+-- AddForeignKey
+ALTER TABLE "List" ADD CONSTRAINT "List_ownedByHandle_fkey" FOREIGN KEY ("ownedByHandle") REFERENCES "User"("handle") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20230224125201_change_submitted_verified_fields/migration.sql
+++ b/prisma/migrations/20230224125201_change_submitted_verified_fields/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `submitted` on the `List` table. All the data in the column will be lost.
+  - You are about to drop the column `verified` on the `List` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "List" DROP COLUMN "submitted",
+DROP COLUMN "verified",
+ADD COLUMN     "submittedAt" TIMESTAMP(3);
+
+-- CreateTable
+CREATE TABLE "ListVerification" (
+    "verifiedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "listId" INTEGER NOT NULL,
+    "userHandle" CITEXT NOT NULL,
+
+    CONSTRAINT "ListVerification_pkey" PRIMARY KEY ("listId")
+);
+
+-- AddForeignKey
+ALTER TABLE "ListVerification" ADD CONSTRAINT "ListVerification_listId_fkey" FOREIGN KEY ("listId") REFERENCES "List"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ListVerification" ADD CONSTRAINT "ListVerification_userHandle_fkey" FOREIGN KEY ("userHandle") REFERENCES "User"("handle") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,17 +12,18 @@ datasource db {
 }
 
 model User {
-  handle       String      @id @db.Citext
-  name         String
-  email        String?     @unique
-  passwordHash String
-  role         Role        @default(BASE)
-  createdLists List[]      @relation(name: "listCreator")
-  ownedLists   List[]      @relation(name: "listOwner")
-  visible      Boolean     @default(true)
-  lastSignedIn DateTime?
-  token        UserToken?
-  resetToken   ResetToken?
+  handle        String             @id @db.Citext
+  name          String
+  email         String?            @unique
+  passwordHash  String
+  role          Role               @default(BASE)
+  createdLists  List[]             @relation(name: "listCreator")
+  ownedLists    List[]             @relation(name: "listOwner")
+  verifiedLists ListVerification[]
+  visible       Boolean            @default(true)
+  lastSignedIn  DateTime?
+  token         UserToken?
+  resetToken    ResetToken?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now())
@@ -39,7 +40,7 @@ model UserToken {
 }
 
 model List {
-  id          Int      @id @default(autoincrement())
+  id          Int               @id @default(autoincrement())
   type        String
   version     String
   structure   Json
@@ -49,15 +50,24 @@ model List {
   phoneNumber String?
   eventDate   String?
   comment     String?
-  submitted   Boolean  @default(false)
-  verified    Boolean  @default(false)
-  createdBy   User     @relation(fields: [createdByHandle], references: [handle], name: "listCreator")
-  ownedBy     User?    @relation(fields: [ownedByHandle], references: [handle], name: "listOwner")
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @default(now())
+  submittedAt DateTime?
+  verified    ListVerification?
+  createdBy   User              @relation(fields: [createdByHandle], references: [handle], name: "listCreator")
+  ownedBy     User?             @relation(fields: [ownedByHandle], references: [handle], name: "listOwner")
+  createdAt   DateTime          @default(now())
+  updatedAt   DateTime          @default(now())
 
   createdByHandle String  @db.Citext
   ownedByHandle   String? @db.Citext
+}
+
+model ListVerification {
+  list       List     @relation(fields: [listId], references: [id], onDelete: Cascade)
+  verifiedAt DateTime @default(now())
+  verifiedBy User     @relation(fields: [userHandle], references: [handle], onDelete: Cascade)
+
+  listId     Int    @id
+  userHandle String @db.Citext
 }
 
 model Secret {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,7 @@ model User {
   passwordHash String
   role         Role        @default(BASE)
   createdLists List[]      @relation(name: "listCreator")
+  ownedLists   List[]      @relation(name: "listOwner")
   visible      Boolean     @default(true)
   lastSignedIn DateTime?
   token        UserToken?
@@ -51,10 +52,12 @@ model List {
   submitted   Boolean  @default(false)
   verified    Boolean  @default(false)
   createdBy   User     @relation(fields: [createdByHandle], references: [handle], name: "listCreator")
+  ownedBy     User?    @relation(fields: [ownedByHandle], references: [handle], name: "listOwner")
   createdAt   DateTime @default(now())
   updatedAt   DateTime @default(now())
 
-  createdByHandle String @db.Citext
+  createdByHandle String  @db.Citext
+  ownedByHandle   String? @db.Citext
 }
 
 model Secret {

--- a/src/server/list/list.model.ts
+++ b/src/server/list/list.model.ts
@@ -1,14 +1,15 @@
 import { phoneNumberRegex } from '../../utils/regex';
 import validateDate from '../../utils/validateDate';
-import { MinimalUser } from '../user/user.model';
+import { MinimalUser, UsableUser } from '../user/user.model';
 
 export type MinimalList = {
 	id: number;
 	type: string;
 	version: string;
 	eventDate: string | null;
-	submitted: boolean;
-	verified: boolean;
+	status: ListStatus;
+	submittedAt: Date | null;
+	verified: ListVerification | null;
 };
 
 export type UsableList = {
@@ -22,13 +23,25 @@ export type UsableList = {
 	phoneNumber: string | null;
 	eventDate: string | null;
 	comment: string | null;
-	submitted: boolean;
-	verified: boolean;
+	status: ListStatus;
+	submittedAt: Date | null;
+	verified: ListVerification | null;
 	createdBy: MinimalUser;
 	ownedBy: MinimalUser;
 };
 
-export type MissingOwnerList = Omit<UsableList, 'ownedBy'> & { ownedBy: MinimalUser | null };
+export type IncompleteMinimalList = Omit<MinimalList, 'status'>;
+
+export type IncompleteUsableList = Omit<UsableList, 'ownedBy' | 'status'> & {
+	ownedBy: MinimalUser | null;
+};
+
+export type ListStatus = 'open' | 'submitted' | 'verified';
+
+export type ListVerification = {
+	verifiedAt: Date;
+	verifiedBy: MinimalUser;
+};
 
 export type Structure = {
 	name: string;

--- a/src/server/list/list.model.ts
+++ b/src/server/list/list.model.ts
@@ -1,4 +1,4 @@
-import { dateRegex, phoneNumberRegex } from '../../utils/regex';
+import { phoneNumberRegex } from '../../utils/regex';
 import validateDate from '../../utils/validateDate';
 import { MinimalUser } from '../user/user.model';
 
@@ -25,7 +25,10 @@ export type UsableList = {
 	submitted: boolean;
 	verified: boolean;
 	createdBy: MinimalUser;
+	ownedBy: MinimalUser;
 };
+
+export type MissingOwnerList = Omit<UsableList, 'ownedBy'> & { ownedBy: MinimalUser | null };
 
 export type Structure = {
 	name: string;
@@ -48,6 +51,7 @@ export type UpdateListProps = {
 	comment?: string | null;
 	submitted?: boolean;
 	verified?: boolean;
+	owner?: string;
 };
 
 export function isCreateListProps(props: any): props is CreateListProps {
@@ -74,7 +78,8 @@ export function isUpdateListProps(props: any): props is UpdateListProps {
 		(listProps.eventDate === undefined || validateDate(listProps.eventDate)) &&
 		(['string', 'undefined'].includes(typeof listProps.comment) || listProps.comment === null) &&
 		['boolean', 'undefined'].includes(typeof listProps.submitted) &&
-		['boolean', 'undefined'].includes(typeof listProps.verified)
+		['boolean', 'undefined'].includes(typeof listProps.verified) &&
+		['string', 'undefined'].includes(typeof listProps.owner)
 	);
 }
 

--- a/src/server/list/list.routes.ts
+++ b/src/server/list/list.routes.ts
@@ -95,13 +95,13 @@ export default function (server: Express) {
 					.send('Must be owner of the list or a moderator to change those properties');
 
 			if (props.owner) {
-				if (list.submitted)
+				if (list.submittedAt)
 					return res.status(409).send("It's not possible to change owner of a submitted list");
 				if (!(await findUser(props.owner)))
 					return res.status(404).send(`No user with the handle '${props.owner}' exists`);
 			}
 
-			if (props.verified && !list.submitted)
+			if (props.verified && !list.submittedAt)
 				return res.status(409).send("It's not possible to verify a list that isn't submitted");
 			if (
 				props.verified !== undefined &&
@@ -121,7 +121,9 @@ export default function (server: Express) {
 			)
 				return res.status(409).send(`Can't submit a list that is missing required properties`);
 
-			const updatedList = await updateList(id, props, list);
+			if (props.submitted && list.ownedBy.handle !== caller.handle) props.owner = caller.handle;
+
+			const updatedList = await updateList(id, props, list, caller);
 
 			res.status(200).send(updatedList);
 		})

--- a/src/server/list/list.service.ts
+++ b/src/server/list/list.service.ts
@@ -1,11 +1,14 @@
+import { Prisma } from '@prisma/client';
 import prismaClient from '../../prismaClient';
 import { UsableUser } from '../user/user.model';
 import {
 	CreateListProps,
 	MinimalList,
-	MissingOwnerList,
+	IncompleteUsableList,
 	UpdateListProps,
 	UsableList,
+	IncompleteMinimalList,
+	ListStatus,
 } from './list.model';
 
 type FindListsFilter = {
@@ -15,25 +18,29 @@ type FindListsFilter = {
 export async function findLists(filter: FindListsFilter = {}): Promise<MinimalList[]> {
 	const { createdBy: createdByHandle } = filter;
 
-	return await prismaClient.list.findMany({
-		select: {
-			id: true,
-			type: true,
-			version: true,
-			eventDate: true,
-			submitted: true,
-			verified: true,
-		},
-		where: createdByHandle ? { createdByHandle } : undefined,
-		orderBy: { updatedAt: 'desc' },
-	});
+	return await prismaClient.list
+		.findMany({
+			select: {
+				id: true,
+				type: true,
+				version: true,
+				eventDate: true,
+				submittedAt: true,
+				verified: {
+					select: { verifiedAt: true, verifiedBy: true },
+				},
+			},
+			where: createdByHandle ? { createdByHandle } : undefined,
+			orderBy: { updatedAt: 'desc' },
+		})
+		.then((lists) => lists.map((l) => makeListMinimal(l)));
 }
 
 export async function findList(id: number): Promise<UsableList | null> {
 	const list = (await prismaClient.list.findUnique({
 		where: { id },
 		select: listSelect,
-	})) as MissingOwnerList | null;
+	})) as IncompleteUsableList | null;
 
 	return makeListUsable(list);
 }
@@ -51,37 +58,63 @@ export async function createList(props: CreateListProps, creator: UsableUser): P
 	const list = (await prismaClient.list.create({
 		data: { ...props, fields, createdBy: { connect: { handle: creator.handle } } },
 		select: listSelect,
-	})) as MissingOwnerList;
+	})) as unknown as IncompleteUsableList;
 
 	return makeListUsable(list);
 }
 
 export async function updateList(
 	id: number,
-	{ fields, owner, ...props }: UpdateListProps,
-	existingList: UsableList
+	{ fields, owner, submitted, verified: setVerified, ...props }: UpdateListProps,
+	existingList: UsableList,
+	user?: UsableUser
 ): Promise<UsableList> {
 	const newFields = fields && { ...existingList.fields, ...fields };
+	const submittedAt = submitted === undefined ? undefined : submitted ? new Date() : null;
+	const verified =
+		setVerified === undefined || !user
+			? undefined
+			: setVerified
+			? { create: { userHandle: user.handle } }
+			: { delete: true };
 	const list = (await prismaClient.list.update({
 		where: { id },
-		data: { ...props, fields: newFields, updatedAt: new Date(), ownedByHandle: owner },
+		data: {
+			...props,
+			submittedAt,
+			verified,
+			fields: newFields,
+			updatedAt: new Date(),
+			ownedByHandle: owner,
+		},
 		select: listSelect,
-	})) as MissingOwnerList;
+	})) as unknown as IncompleteUsableList;
 
 	return makeListUsable(list);
 }
 
-function makeListUsable(list: null): null;
-function makeListUsable(list: MissingOwnerList): UsableList;
-function makeListUsable(list: MissingOwnerList | null): UsableList | null;
-function makeListUsable(list: MissingOwnerList | null): UsableList | null {
-	if (!list) return null;
-	if (list.ownedBy) return list as UsableList;
-
-	return { ...list, ownedBy: list.createdBy };
+function listStatus(list: IncompleteUsableList | IncompleteMinimalList): ListStatus {
+	if (list.verified) return 'verified';
+	if (list.submittedAt) return 'submitted';
+	return 'open';
 }
 
-const listSelect = {
+function makeListMinimal(list: IncompleteMinimalList): MinimalList;
+function makeListMinimal(list: IncompleteMinimalList | null): MinimalList | null;
+function makeListMinimal(list: IncompleteMinimalList | null): MinimalList | null {
+	if (!list) return null;
+	return { ...list, status: listStatus(list) };
+}
+
+function makeListUsable(list: IncompleteUsableList): UsableList;
+function makeListUsable(list: IncompleteUsableList | null): UsableList | null;
+function makeListUsable(list: IncompleteUsableList | null): UsableList | null {
+	if (!list) return null;
+	if (!list.ownedBy) list.ownedBy = list.createdBy;
+	return { ...list, status: listStatus(list) } as UsableList;
+}
+
+const listSelect: Prisma.ListSelect = {
 	id: true,
 	type: true,
 	version: true,
@@ -92,8 +125,8 @@ const listSelect = {
 	phoneNumber: true,
 	eventDate: true,
 	comment: true,
-	submitted: true,
-	verified: true,
+	submittedAt: true,
+	verified: { select: { verifiedAt: true, verifiedBy: true } },
 	createdBy: { select: { handle: true, name: true, role: true } },
 	ownedBy: { select: { handle: true, name: true, role: true } },
 };

--- a/src/server/user/user.routes.ts
+++ b/src/server/user/user.routes.ts
@@ -28,6 +28,8 @@ import {
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime';
 import route from '../../utils/route';
 import bodyFilter from '../../utils/bodyFilter';
+import { getQueryField } from '../../utils/parseQuery';
+import { parseRole } from '../../utils/parser';
 
 export default function (server: Express) {
 	server.get(
@@ -36,7 +38,12 @@ export default function (server: Express) {
 			const caller = await tokenAuthentication(req, res);
 			if (!caller) return res.headersSent || res.sendStatus(500);
 
-			const users = await findUsers();
+			const page = getQueryField(req, 'page', Number);
+			const limit = getQueryField(req, 'limit', Number);
+			const search = getQueryField(req, 'search');
+			const role = getQueryField(req, 'role', parseRole);
+
+			const users = await findUsers({ search, role }, { page, limit });
 			res.status(200).send(users);
 		})
 	);

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,0 +1,1 @@
+export type PaginationParams = { limit: number; page: number };

--- a/src/utils/parseQuery.ts
+++ b/src/utils/parseQuery.ts
@@ -1,0 +1,17 @@
+import { Request } from 'express';
+
+export function getQueryField<T = string>(
+	req: Request,
+	field: string,
+	parser?: (param: string) => T
+): T | undefined {
+	const param = req.query[field];
+	if (!param) return undefined;
+
+	let value = param;
+	if (Array.isArray(param)) value = param[0];
+
+	if (!parser) return value as T;
+
+	return parser(value as string);
+}

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -1,0 +1,6 @@
+import { Role } from '@prisma/client';
+
+export function parseRole(role: string): Role | undefined {
+	if (!Object.values(Role).includes(role as Role)) return undefined;
+	return role as Role;
+}

--- a/test/factories/list.factory.ts
+++ b/test/factories/list.factory.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { MinimalList, UsableList } from '../../src/server/list/list.model';
+import { MinimalUser } from '../../src/server/user/user.model';
 import factory from './factory';
 
 export const minimalListFactory = factory<MinimalList>(() => ({
@@ -11,18 +12,26 @@ export const minimalListFactory = factory<MinimalList>(() => ({
 	verified: false,
 }));
 
-export const usableListFactory = factory<UsableList>(() => ({
-	id: 1,
-	type: faker.lorem.word(),
-	version: 'v' + faker.random.numeric(1),
-	structure: [],
-	fields: {},
-	colors: null,
-	responsible: null,
-	phoneNumber: null,
-	eventDate: null,
-	comment: null,
-	submitted: false,
-	verified: false,
-	createdBy: { handle: faker.internet.userName(), name: faker.name.fullName(), role: 'BASE' },
-}));
+export const usableListFactory = factory<UsableList>(() => {
+	const creator: MinimalUser = {
+		handle: faker.internet.userName(),
+		name: faker.name.fullName(),
+		role: 'BASE',
+	};
+	return {
+		id: 1,
+		type: faker.lorem.word(),
+		version: 'v' + faker.random.numeric(1),
+		structure: [],
+		fields: {},
+		colors: null,
+		responsible: null,
+		phoneNumber: null,
+		eventDate: null,
+		comment: null,
+		submitted: false,
+		verified: false,
+		createdBy: creator,
+		ownedBy: creator,
+	};
+});

--- a/test/factories/list.factory.ts
+++ b/test/factories/list.factory.ts
@@ -8,8 +8,9 @@ export const minimalListFactory = factory<MinimalList>(() => ({
 	type: faker.lorem.word(),
 	version: 'v' + faker.random.numeric(1),
 	eventDate: null,
-	submitted: false,
-	verified: false,
+	status: 'open',
+	submittedAt: null,
+	verified: null,
 }));
 
 export const usableListFactory = factory<UsableList>(() => {
@@ -29,8 +30,9 @@ export const usableListFactory = factory<UsableList>(() => {
 		phoneNumber: null,
 		eventDate: null,
 		comment: null,
-		submitted: false,
-		verified: false,
+		status: 'open',
+		submittedAt: null,
+		verified: null,
 		createdBy: creator,
 		ownedBy: creator,
 	};

--- a/test/src/server/user.routes.test.ts
+++ b/test/src/server/user.routes.test.ts
@@ -77,7 +77,7 @@ describe('GET /users', () => {
 	it('returns 200 for correct request', async () => {
 		when(tokenAuthentication).mockResolvedValue(primary);
 		const users = minimalUserFactory([{}, {}, {}]);
-		when(findUsers).calledWith().mockResolvedValue(users);
+		when(findUsers).calledWith({}, {}).mockResolvedValue(users);
 
 		const response = await supertest(server).get('/users');
 

--- a/test/src/utils/parseQuery.test.ts
+++ b/test/src/utils/parseQuery.test.ts
@@ -1,0 +1,28 @@
+import { Request } from 'express';
+import { getQueryField } from '../../../src/utils/parseQuery';
+
+describe('getQueryField', () => {
+	test('Returns string without parser', () => {
+		const req = { query: { foo: 'bar' } } as unknown as Request;
+
+		expect(getQueryField(req, 'foo')).toBe('bar');
+	});
+
+	test('Returns first string from array without parser', () => {
+		const req = { query: { foo: ['bar', 'zot'] } } as unknown as Request;
+
+		expect(getQueryField(req, 'foo')).toBe('bar');
+	});
+
+	test('Returns value through parser', () => {
+		const req = { query: { foo: '7' } } as unknown as Request;
+
+		expect(getQueryField(req, 'foo', Number)).toBe(7);
+	});
+
+	test('Returns undefined for missing query parameter', () => {
+		const req = { query: { bar: 'zot' } } as unknown as Request;
+
+		expect(getQueryField(req, 'foo')).toBeUndefined();
+	});
+});

--- a/test/src/utils/parser.test.ts
+++ b/test/src/utils/parser.test.ts
@@ -1,0 +1,14 @@
+import { Role } from '@prisma/client';
+import { parseRole } from '../../../src/utils/parser';
+
+describe('parseRole', () => {
+	test('Returns same when called with role', () => {
+		const role: Role = 'MANAGER';
+		expect(parseRole(role)).toBe(role);
+	});
+
+	test('Returns undefined when called with non-role', () => {
+		const role = 'foo_bar-zot';
+		expect(parseRole(role)).toBeUndefined();
+	});
+});


### PR DESCRIPTION
- Allows lists to be transfered to another user
- Allows params to filter users when GETting many

Resolves #22
Resolves #20

- Makes submitted track time of submission
- Makes verified track time of verification and user who performed verification
- Adds `status` property to lists

Resolves #25